### PR TITLE
Using External Library during runtime

### DIFF
--- a/CloudCoderBuilder2/src/org/cloudcoder/builder2/javaprogram/JavaProgramToCommandForEachCommandInputBuildStep.java
+++ b/CloudCoderBuilder2/src/org/cloudcoder/builder2/javaprogram/JavaProgramToCommandForEachCommandInputBuildStep.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import org.cloudcoder.builder2.javacompiler.JavaCompilerBuildStep;
 import org.cloudcoder.builder2.model.BuilderSubmission;
 import org.cloudcoder.builder2.model.BytecodeExecutable;
 import org.cloudcoder.builder2.model.Command;


### PR DESCRIPTION
I think user-specified external libraries should also be used during runtime. This is required in order to successfully use media computation (pictures, sounds, etc) in problem sets.
